### PR TITLE
Use repr() when printing user-provided text.

### DIFF
--- a/setti.py
+++ b/setti.py
@@ -24,7 +24,7 @@ def Save(page="", text="", printOutput=True):
     '''The Save command can be used to submit text to a page.'''
     requests.post("http://htwins.net/edit/" + page, data={'content': text})
     if printOutput:
-        print(text)
+        print(repr(text))
 
 
 def Read(page=""):
@@ -59,7 +59,7 @@ def Append(page="", text="", printOutput=True, sep="\n"):
     '''The Append command can be used to append text to an existing page's content.'''
     Save(page, '{}{}{}'.format(Read(page), sep, text), False)
     if printOutput:
-        print("Appended {} to {}.".format(text, page))
+        print("Appended {} to {}.".format(repr(text), page))
 
 
 def Export(page="", filename="page.txt", printOutput=True):


### PR DESCRIPTION
This change uses `repr()` when printing user-provided text.

Here's a _snippet_ of [**repr()**](https://docs.python.org/3/library/functions.html#repr)'s documentation that explains what it does:
* > Return a string containing a printable representation of an object

_**<sub>Ready to merge.</sub>**_